### PR TITLE
Add iPhone 12 device frame wrapper for desktop view

### DIFF
--- a/frontend/src/components/DeviceFrame/DeviceFrame.css
+++ b/frontend/src/components/DeviceFrame/DeviceFrame.css
@@ -1,0 +1,50 @@
+.device-stage {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow: auto;
+  background: radial-gradient(
+    circle at 50% 25%,
+    #2b3a45 0%,
+    #0a2533 55%,
+    #06161d 100%
+  );
+}
+
+.device-frame {
+  position: relative;
+  flex: 0 0 auto;
+  width: 414px; /* 390px Screen + 2x12px Rand */
+  height: min(868px, calc(100vh - 48px)); /* 844px Screen + Rand */
+  padding: 12px;
+  background: #0b0b0d;
+  border-radius: 56px;
+  box-shadow: 0 0 0 2px #1c1c1e, 0 30px 70px rgba(0, 0, 0, 0.55),
+    0 12px 24px rgba(0, 0, 0, 0.4);
+}
+
+.device-screen {
+  display: block;
+  width: 390px;
+  height: 100%;
+  border: 0;
+  border-radius: 44px;
+  background: #f1f5f5;
+}
+
+/* Notch / Dynamic-Island-Andeutung */
+.device-notch {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 24px;
+  background: #0b0b0d;
+  border-radius: 0 0 16px 16px;
+  z-index: 2;
+  pointer-events: none;
+}

--- a/frontend/src/components/DeviceFrame/DeviceFrame.jsx
+++ b/frontend/src/components/DeviceFrame/DeviceFrame.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import "./DeviceFrame.css";
+
+// Ab dieser Fensterbreite wird die App im iPhone-12-Rahmen gezeigt.
+// Darunter (echtes Handy / schmales Fenster) rendern wir die App direkt.
+const FRAME_BREAKPOINT = 900;
+
+export default function DeviceFrame({ children }) {
+  const [showFrame, setShowFrame] = useState(
+    () => window.innerWidth > FRAME_BREAKPOINT
+  );
+
+  useEffect(() => {
+    const onResize = () => setShowFrame(window.innerWidth > FRAME_BREAKPOINT);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  if (!showFrame) {
+    return children;
+  }
+
+  // Gleiche App, aber via ?embedded geladen -> main.jsx rendert dort die App
+  // statt erneut den Rahmen (verhindert Endlos-Verschachtelung).
+  const src = `${window.location.pathname}?embedded${window.location.hash}`;
+
+  return (
+    <div className="device-stage">
+      <div className="device-frame">
+        <div className="device-notch" />
+        <iframe
+          className="device-screen"
+          src={src}
+          title="Silentmoon – iPhone 12 Vorschau"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
+import DeviceFrame from "./components/DeviceFrame/DeviceFrame.jsx";
 import "./index.css";
 
 import { BrowserRouter } from "react-router-dom";
@@ -10,18 +11,29 @@ import { VideoDataProvider } from "./context/VideoDataContext.jsx";
 import { UserDataProvider } from "./context/UserDataContext.jsx";
 import { DeezerDataProvider } from "./context/DeezerDataContext.jsx";
 
+// Im iframe (?embedded) rendern wir die reine App, sonst den iPhone-12-Rahmen.
+// Der window.top-Check greift, wenn im iframe neu geladen wird und dabei der
+// Query-Parameter verloren geht.
+const isEmbedded =
+  new URLSearchParams(window.location.search).has("embedded") ||
+  window.self !== window.top;
+
+const app = (
+  <BrowserRouter>
+    <UserDataProvider>
+      <UserProvider>
+        <VideoDataProvider>
+          <DeezerDataProvider>
+            <App />
+          </DeezerDataProvider>
+        </VideoDataProvider>
+      </UserProvider>
+    </UserDataProvider>
+  </BrowserRouter>
+);
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <UserDataProvider>
-        <UserProvider>
-          <VideoDataProvider>
-            <DeezerDataProvider>
-              <App />
-            </DeezerDataProvider>
-          </VideoDataProvider>
-        </UserProvider>
-      </UserDataProvider>
-    </BrowserRouter>
+    {isEmbedded ? app : <DeviceFrame>{app}</DeviceFrame>}
   </React.StrictMode>
 );


### PR DESCRIPTION
Portiert den iPhone-12-Rahmen aus AlpayC/Tasty#1 nach Silentmoon.

Ab einer Fensterbreite von 900px wird die App in einem iPhone-12-Rahmen (390x844) auf einer abgedunkelten Bühne gerendert, statt über die volle Desktop-Breite zu laufen. Darunter — echtes Handy oder schmales Fenster — rendert die App wie bisher direkt, ohne Rahmen.

## Umsetzung

- `components/DeviceFrame/DeviceFrame.jsx` + `.css` — der Rahmen; lädt die App per iframe mit `?embedded`
- `main.jsx` — rendert `?embedded` als reine App, sonst den Rahmen; verhindert Endlos-Verschachtelung

Abweichungen von der Tasty-Vorlage:

- `DeviceFrame` bekommt die App als `children`, statt `App.jsx` selbst zu importieren — Silentmoon hat den Provider-Baum (Router, User, VideoData, DeezerData) in `main.jsx`, der so nur einmal definiert bleibt.
- Zusätzlicher `window.self !== window.top`-Check: geht beim Reload im iframe der Query-Parameter verloren, würde sonst der Rahmen im Rahmen landen.
- Die Tasty-spezifische Desktop-CSS (App.css, Nav.css, Categories.css, Details.css) ist nicht übernommen — die Selektoren existieren hier nicht, und in einem 390px-Rahmen wäre Desktop-Layout ohnehin wirkungslos.
- Die `html, body, #root { height: 100% }`-Regel aus Tastys `index.css` ist weggelassen: `.device-stage` ist `position: fixed`, braucht sie also nicht, und sie hätte bestehende `height: 100%`-Regeln in DetailsYoga/DetailsMeditation beeinflussen können.

## Test

- `npm run build` läuft durch
- Dev-Server liefert `/` und `/?embedded` mit 200
- Nicht visuell geprüft — bitte im Browser gegenchecken (Rahmen ab >900px, Umschalten beim Resize)

CSP ist unkritisch: der iframe ist same-origin, `default-src 'self'` und helmets `X-Frame-Options: SAMEORIGIN` decken das ab.