### PR TITLE
Fix horizontal overflow on Home and hide scrollbars in device frame

### DIFF
--- a/frontend/src/components/RandomHomeCardYoga/RandomHomeCardYoga.css
+++ b/frontend/src/components/RandomHomeCardYoga/RandomHomeCardYoga.css
@@ -1,6 +1,6 @@
 .random-img-container {
 	position: relative;
-	width: 45vw;
+	width: 100%;
 	overflow: hidden;
 	margin-bottom: 3rem;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,19 @@ html {
   font-size: 62.5%;
 }
 
+/* Im iPhone-Rahmen (?embedded) keine Desktop-Scrollbalken zeigen. Gescrollt
+   wird weiterhin, nur ohne sichtbare Leiste - wie auf einem echten Geraet. */
+html.embedded,
+html.embedded * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+html.embedded::-webkit-scrollbar,
+html.embedded *::-webkit-scrollbar {
+  display: none;
+}
+
 a {
   color: var(--pink);
   text-decoration: none;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -18,6 +18,11 @@ const isEmbedded =
   new URLSearchParams(window.location.search).has("embedded") ||
   window.self !== window.top;
 
+// Markiert das Dokument im Rahmen, damit index.css die Scrollbalken ausblendet.
+if (isEmbedded) {
+  document.documentElement.classList.add("embedded");
+}
+
 const app = (
   <BrowserRouter>
     <UserDataProvider>

--- a/frontend/src/pages/Home/Home.css
+++ b/frontend/src/pages/Home/Home.css
@@ -4,6 +4,13 @@
 	gap: 2rem;
 }
 
+/* Die Kacheln teilen sich die verfuegbare Breite, statt sie mit festen
+   vw-Werten zu ueberschreiten. min-width haelt die Links schrumpffaehig. */
+.suggestions > a {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
 .home-wrapper {
 	text-align: left;
 }


### PR DESCRIPTION
Behebt die Scrollbalken, die im iPhone-Rahmen sichtbar wurden.

## Horizontaler Scrollbalken auf Home

Ursache waren die beiden Kacheln unter der Begrüßung: `.random-img-container` war auf `width: 45vw` fixiert. Zwei Kacheln plus `gap: 2rem` plus das Padding von `.main-wrapper` ergeben mehr als 100vw — im 390px-Frame rund 391px. Dazu kommt, dass die Flex-Items `<a>`-Elemente sind, die wegen `min-width: auto` nicht unter ihre Inhaltsbreite schrumpfen können, das Layout also nicht selbst korrigieren konnte.

Statt die vw-Werte nachzujustieren teilen sich die Kacheln jetzt die tatsächlich verfügbare Breite:

- `RandomHomeCardYoga.css` — `width: 45vw` → `width: 100%`
- `Home.css` — `.suggestions > a { flex: 1 1 0; min-width: 0; }`

Damit passt die Sektion in jeder Breite, nicht nur bei 390px.

## Vertikale Scrollbalken

Im Rahmen (`?embedded`) werden die Desktop-Scrollbalken ausgeblendet — gescrollt wird weiterhin, nur ohne sichtbare Leiste, wie auf einem echten Gerät. Das trifft auch die horizontale Leiste der `.slider`-Komponente, die durch `overflow-x: scroll` dauerhaft sichtbar war.

- `main.jsx` — setzt im eingebetteten Fall die Klasse `embedded` auf `<html>`
- `index.css` — `scrollbar-width: none` / `::-webkit-scrollbar { display: none }` unter `html.embedded`

Die Regeln greifen nur im Rahmen, die echte mobile Ansicht bleibt unberührt.

## Geprüft, aber nicht geändert

- `MediationPlayer.css` `min-width: 100vw` — die Seite liegt nicht in `.main-wrapper`, kein zusätzliches Padding, also kein Overflow
- `Reminder.css` `65vw`/`70vw` — bleiben unter der verfügbaren Breite
- `RandomHomeCardMeditation` nutzt dieselbe `.random-img-container`-Klasse, die Komponente wird aber nirgends eingebunden

## Test

- `npm run build` läuft durch
- Dev-Server liefert `/?embedded` mit 200
- Nicht visuell geprüft — bitte im Frame gegenchecken