### PR TITLE
Trust the reverse proxy so rate limiting sees the real client IP

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,13 @@ const PORT = process.env.PORT || 3002;
 // Force restart
 const app = express();
 
+// Hinter dem Reverse Proxy (Traefik bei Coolify) steht die echte Client-IP in
+// X-Forwarded-For. Ohne diese Einstellung sieht express-rate-limit nur die
+// Proxy-IP und zaehlt alle Nutzer als einen. Bewusst 1 statt true: true wuerde
+// der gesamten Kette vertrauen, sodass Clients den Header faelschen und das
+// Rate Limiting umgehen koennten.
+app.set("trust proxy", 1);
+
 const ReactAppDistPath = new URL("../frontend/dist/", import.meta.url);
 const ReactAppIndex = new URL("../frontend/dist/index.html", import.meta.url);
 


### PR DESCRIPTION
Behebt die `ValidationError: ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` aus dem Container-Log.

## Ursache

Coolify stellt Traefik vor den Container, der setzt `X-Forwarded-For`. Express vertraut dem Header aber standardmäßig nicht (`trust proxy` ist `false`), also bleibt `req.ip` die Proxy-IP. `express-rate-limit` erkennt diese Kombination und warnt bei jedem Request.

Das war nicht nur Log-Rauschen: alle Nutzer teilten sich einen Zähler. Das generelle Limit von 1000 Requests/15min galt damit für die gesamte Instanz statt pro Client — unter Last hätte das zu 429ern für unbeteiligte Nutzer geführt.

## Fix

`app.set("trust proxy", 1)` in `backend/server.js`, vor den Rate-Limiting-Middlewares.

Bewusst `1` und nicht `true`: `true` würde der gesamten Weiterleitungskette vertrauen, sodass ein Client sich per selbst gesetztem `X-Forwarded-For` eine beliebige IP geben und das Rate Limiting umgehen könnte. `1` vertraut genau dem einen Hop (Traefik).

Sollte später noch ein Proxy davor kommen (z.B. Cloudflare), muss der Wert entsprechend auf die Zahl der Hops erhöht werden.

## Test

Isoliert nachgestellt mit `express` + `express-rate-limit` aus `backend/node_modules`, Request mit `X-Forwarded-For: 203.0.113.7`:

```
ohne trust proxy (Zustand vor dem Fix)
  req.ip          = ::ffff:127.0.0.1
  ValidationError = JA

app.set("trust proxy", 1)  (Fix)
  req.ip          = 203.0.113.7
  ValidationError = nein
```

Der volle Server liess sich lokal nicht starten (kein `.env`, keine DB) — geprüft ist damit der Mechanismus, nicht der laufende Container. Nach dem Deploy sollte der Fehler aus dem Log verschwinden.