### PR TITLE
Add structured request and error logging to the server

### DIFF
--- a/backend/deezer/deezer.js
+++ b/backend/deezer/deezer.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import axios from "axios";
+import { logger } from "../middleware/logger.js";
 
 export const deezerRouter = Router();
 
@@ -15,7 +16,7 @@ deezerRouter.get("/playlist", async (req, res) => {
     
     res.json(response.data);
   } catch (error) {
-    console.error("Error fetching Deezer playlists:", error);
+    logger.error("Fetching Deezer playlists failed", { error, reqId: req.id });
     res.status(500).json({ error: "Failed to fetch playlists" });
   }
 });
@@ -26,7 +27,7 @@ deezerRouter.post("/tracks", async (req, res) => {
     const response = await axios.get(`${DEEZER_BASE_URL}/playlist/${id}/tracks`);
     res.json(response.data);
   } catch (error) {
-    console.error("Error fetching Deezer tracks:", error);
+    logger.error("Fetching Deezer tracks failed", { error, reqId: req.id });
     res.status(500).json({ error: "Failed to fetch tracks" });
   }
 });
@@ -37,7 +38,7 @@ deezerRouter.get("/onetrack/:id", async (req, res) => {
     const response = await axios.get(`${DEEZER_BASE_URL}/track/${id}`);
     res.json(response.data);
   } catch (error) {
-    console.error("Error fetching Deezer track:", error);
+    logger.error("Fetching Deezer track failed", { error, reqId: req.id });
     res.status(500).json({ error: "Failed to fetch track" });
   }
 });
@@ -88,7 +89,7 @@ deezerRouter.post("/getPlaylistDetails", async (req, res) => {
       res.status(400).json({ error: "Either 'id' or 'ids' parameter is required" });
     }
   } catch (error) {
-    console.error("Error fetching Deezer playlist details:", error);
+    logger.error("Fetching Deezer playlist details failed", { error, reqId: req.id });
     res.status(500).json({ error: "Failed to fetch playlist details" });
   }
 });

--- a/backend/middleware/logger.js
+++ b/backend/middleware/logger.js
@@ -1,0 +1,77 @@
+import { randomUUID } from "crypto";
+
+const LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+
+// Ueber LOG_LEVEL steuerbar, Standard "info". Unbekannte Werte fallen auf info
+// zurueck, damit ein Tippfehler in der Env nicht das komplette Log abschaltet.
+const threshold = LEVELS[process.env.LOG_LEVEL] ?? LEVELS.info;
+
+const timestamp = () => new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+
+function write(level, message, { error, reqId } = {}) {
+  if (LEVELS[level] > threshold) return;
+
+  // Fehler auf stderr, alles andere auf stdout - so kann der Log-Viewer die
+  // beiden Stroeme unterscheiden.
+  const stream = level === "error" ? process.stderr : process.stdout;
+
+  let line = `${timestamp()} ${level.toUpperCase().padEnd(5)} ${message}`;
+
+  // Ohne Fehler bleibt alles auf einer Zeile, sonst waere das Log doppelt so
+  // lang. Nur der Stack bekommt eine eigene, eingerueckte Zeile.
+  if (error) {
+    const prefix = reqId ? `req-id=${reqId}  ` : "";
+    line += `\n  ${prefix}${error.stack || String(error)}`;
+  } else if (reqId) {
+    line += `  req-id=${reqId}`;
+  }
+
+  stream.write(`${line}\n`);
+}
+
+export const logger = {
+  error: (message, options) => write("error", message, options),
+  warn: (message, options) => write("warn", message, options),
+  info: (message, options) => write("info", message, options),
+  debug: (message, options) => write("debug", message, options),
+};
+
+/*
+ * Loggt jeden abgeschlossenen Request. API-Aufrufe immer, Auslieferung von
+ * statischen Dateien und der SPA nur im Fehlerfall - sonst waeren die Logs von
+ * Bildern und JS-Chunks zugemuellt.
+ */
+export function requestLogger(req, res, next) {
+  req.id = randomUUID().slice(0, 6);
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const isApiRequest = req.originalUrl.startsWith("/api/");
+    if (!isApiRequest && res.statusCode < 400) return;
+
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    const level =
+      res.statusCode >= 500 ? "error" : res.statusCode >= 400 ? "warn" : "info";
+
+    logger[level](
+      `${req.method.padEnd(4)} ${req.originalUrl} ${res.statusCode} ${durationMs.toFixed(0)}ms`,
+      { reqId: req.id }
+    );
+  });
+
+  next();
+}
+
+/*
+ * Letztes Netz fuer Fehler, die keine Route selbst abgefangen hat. Nach aussen
+ * geht bewusst nur eine generische Meldung, Details bleiben im Log.
+ */
+export function errorHandler(err, req, res, next) {
+  logger.error(`${req.method} ${req.originalUrl} - unhandled error`, {
+    error: err,
+    reqId: req.id,
+  });
+
+  if (res.headersSent) return next(err);
+  res.status(500).json({ error: "Internal server error" });
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,7 +22,10 @@ process.on("unhandledRejection", (reason) => {
 });
 process.on("uncaughtException", (err) => {
   logger.error("Uncaught exception - shutting down", { error: err });
-  process.exit(1);
+  // Im Container sind stdout/stderr Pipes und schreiben asynchron. Ein
+  // sofortiges process.exit() wuerde ausgerechnet diese letzte Zeile
+  // verschlucken - also dem Schreibvorgang kurz Zeit lassen.
+  setTimeout(() => process.exit(1), 100).unref();
 });
 
 mongoose.connection.on("disconnected", () => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,13 +10,31 @@ import { spotifyRouter } from "./spotify/spotify.js";
 import { deezerRouter } from "./deezer/deezer.js";
 import { exercisesRouter } from "./exercises/routes.js";
 import { generalLimiter } from "./middleware/rateLimiting.js";
+import { logger, requestLogger, errorHandler } from "./middleware/logger.js";
 
 dotenv.config({
   path: path.join(path.resolve(), "..", ".env"),
 });
 
+// Fehler, die sonst kommentarlos den Prozess beenden wuerden.
+process.on("unhandledRejection", (reason) => {
+  logger.error("Unhandled promise rejection", { error: reason });
+});
+process.on("uncaughtException", (err) => {
+  logger.error("Uncaught exception - shutting down", { error: err });
+  process.exit(1);
+});
+
+mongoose.connection.on("disconnected", () => {
+  logger.warn("MongoDB connection lost");
+});
+mongoose.connection.on("reconnected", () => {
+  logger.info("MongoDB reconnected");
+});
+
 await mongoose.connect(process.env.DB);
 await mongoose.connection.syncIndexes();
+logger.info("MongoDB connected");
 
 const PORT = process.env.PORT || 3002;
 // Force restart
@@ -28,6 +46,10 @@ const app = express();
 // der gesamten Kette vertrauen, sodass Clients den Header faelschen und das
 // Rate Limiting umgehen koennten.
 app.set("trust proxy", 1);
+
+// Frueh registriert, damit auch Requests im Log landen, die spaeter am Rate
+// Limit oder an einer Validierung scheitern.
+app.use(requestLogger);
 
 const ReactAppDistPath = new URL("../frontend/dist/", import.meta.url);
 const ReactAppIndex = new URL("../frontend/dist/index.html", import.meta.url);
@@ -80,6 +102,9 @@ app.get("/*", (req, res) => {
   res.sendFile(ReactAppIndex.pathname);
 });
 
+// Muss nach allen Routen stehen, damit Express ihn als Error-Handler erkennt.
+app.use(errorHandler);
+
 app.listen(PORT, () => {
-  console.log("Server running on Port: ", PORT);
+  logger.info(`Server running on port ${PORT}`);
 });

--- a/backend/user/routes.js
+++ b/backend/user/routes.js
@@ -11,6 +11,7 @@ import {
   handleValidationErrors 
 } from "../middleware/validation.js";
 import { authLimiter, dataModificationLimiter } from "../middleware/rateLimiting.js";
+import { logger } from "../middleware/logger.js";
 
 export const userRouter = Router();
 
@@ -121,7 +122,7 @@ userRouter.put("/addexercise", dataModificationLimiter, authenticateToken, valid
     await user.save();
     res.send("Video added");
   } catch (err) {
-    console.log("Error:", err);
+    logger.error("User request failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error.");
   }
 });
@@ -139,7 +140,7 @@ userRouter.put("/deleteexercise", dataModificationLimiter, authenticateToken, va
       res.send("Video is not in favorites");
     }
   } catch (err) {
-    console.log("Error:", err);
+    logger.error("User request failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error.");
   }
 });
@@ -161,7 +162,7 @@ userRouter.put("/addplaylist", dataModificationLimiter, authenticateToken, valid
     await user.save();
     res.status(201).send("Playlist added");
   } catch (err) {
-    console.log("Error:", err);
+    logger.error("User request failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error.");
   }
 });
@@ -184,7 +185,7 @@ userRouter.put("/deleteplaylist", dataModificationLimiter, authenticateToken, va
       res.send("Playlist is not in favorites");
     }
   } catch (err) {
-    console.log("Error:", err);
+    logger.error("User request failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error.");
   }
 });
@@ -203,7 +204,7 @@ userRouter.put("/updatereminder", dataModificationLimiter, authenticateToken, va
       res.status(404).send("User not found");
     }
   } catch (err) {
-    console.log("Error:", err);
+    logger.error("User request failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error.");
   }
 });
@@ -280,7 +281,10 @@ userRouter.post("/logsession", dataModificationLimiter, authenticateToken, async
     });
 
   } catch (err) {
-    console.log("Error logging session:", err);
+    logger.error("Logging meditation session failed", {
+      error: err,
+      reqId: req.id,
+    });
     res.status(500).send("There was an error logging the session.");
   }
 });
@@ -332,7 +336,7 @@ userRouter.get("/analytics/:id", authenticateToken, async (req, res) => {
     res.send(analytics);
 
   } catch (err) {
-    console.log("Error fetching analytics:", err);
+    logger.error("Fetching analytics failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error fetching analytics.");
   }
 });
@@ -358,7 +362,7 @@ userRouter.get("/stats/:id", authenticateToken, async (req, res) => {
     res.send(stats);
 
   } catch (err) {
-    console.log("Error fetching stats:", err);
+    logger.error("Fetching stats failed", { error: err, reqId: req.id });
     res.status(500).send("There was an error fetching stats.");
   }
 });


### PR DESCRIPTION
Bisher gab es kein Logging wert der Bezeichnung: keine Bibliothek, keine Request-Logs, kein zentraler Error-Handler — nur 13 verstreute `console.*`-Aufrufe. Die meisten davon in `user/routes.js` mit `console.log("Error:", err)`, also Fehler auf stdout statt stderr, ohne Route, ohne Status, ohne Zuordnung. Im Coolify-Log standen dadurch nur nackte Stack-Traces.

## Neu: `backend/middleware/logger.js`

Bewusst ohne neue Abhängigkeit — rund 70 Zeilen, die genau das tun, was hier gebraucht wird. Drei Teile:

**`logger`** — Level `error`/`warn`/`info`/`debug`, über `LOG_LEVEL` filterbar (Standard `info`, unbekannte Werte fallen auf `info` zurück, damit ein Tippfehler nicht das Log abschaltet). `error` geht auf stderr, der Rest auf stdout.

**`requestLogger`** — vergibt pro Request eine kurze `req.id` und loggt den abgeschlossenen Request mit Methode, Pfad, Status und Dauer. Level richtet sich nach dem Status: 2xx/3xx `INFO`, 4xx `WARN`, 5xx `ERROR`. Früh registriert, damit auch Requests auftauchen, die am Rate Limit oder an einer Validierung scheitern.

**`errorHandler`** — letztes Netz für Fehler, die keine Route abgefangen hat. Loggt mit vollem Kontext, nach außen geht nur eine generische Meldung.

## Angepasst

- `server.js` — Middleware verdrahtet, `unhandledRejection`/`uncaughtException` werden geloggt statt den Prozess kommentarlos zu beenden, MongoDB-Verbindungsverlust und -Rückkehr werden gemeldet
- `user/routes.js`, `deezer/deezer.js` — alle `console.*` durch `logger.error` mit `reqId` ersetzt, keine übrig

## Zwei Entscheidungen

**Statische Dateien werden nicht geloggt**, solange sie mit < 400 antworten. Sonst würde jedes Bild und jeder JS-Chunk das Log fluten. API-Requests immer, alles andere nur im Fehlerfall.

**Kein morgan.** Der Level soll vom Status abhängen, und morgans Stream-API macht das umständlich (drei Instanzen mit `skip`-Regeln). Die eigene Middleware ist kürzer und trifft das Format exakt.

## Test

Mini-Server mit der echten Middleware, alle Pfade ausgelöst:

```
2026-07-31T21:58:39Z INFO  Server running on port 54595
2026-07-31T21:58:39Z INFO  GET  /api/exercises 200 2ms  req-id=8e978a
2026-07-31T21:58:39Z WARN  POST /api/user/login 401 0ms  req-id=0d317d
2026-07-31T21:58:39Z ERROR Fetching analytics failed
  req-id=9b5123  CastError: Cast to ObjectId failed
    at ...
2026-07-31T21:58:39Z ERROR GET  /api/user/analytics 500 0ms  req-id=9b5123
2026-07-31T21:58:39Z ERROR GET /api/boom - unhandled error
  req-id=49f895  Error: kaboom - keine Route hat das abgefangen
    at ...
2026-07-31T21:58:39Z ERROR GET  /api/boom 500 0ms  req-id=49f895
```

Geprüft: Request-ID korreliert Fehler- und Request-Zeile (`9b5123`), der Request auf `/assets/logo.png` taucht korrekt nicht auf, `LOG_LEVEL=warn` blendet die INFO-Zeilen aus.

Der volle Server liess sich lokal nicht starten (kein `.env`, keine DB) — geprüft ist die Middleware, nicht der laufende Container.